### PR TITLE
add the python3 shebang

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3 
+
 import setuptools
 
 with open("README.md", "r", encoding="UTF-8") as f:


### PR DESCRIPTION
Hello! 

# Why this feature?
This feature is very helpful.
The shebang line in any script determines the script's ability be executed like a standalone executable without typing python beforehand in the terminal or when double-clicking it in a file manager (when configured properly). It isn't necessary but generally put there so that when someone sees the file opened in an editor, they immediately know what they're looking at. However, which shebang line you use is important.